### PR TITLE
Fix errors block styling key

### DIFF
--- a/src/AireBootstrapServiceProvider.php
+++ b/src/AireBootstrapServiceProvider.php
@@ -63,7 +63,7 @@ class AireBootstrapServiceProvider extends ServiceProvider
                     'input' => 'is-invalid',
                     'select' => 'is-invalid',
                     'textarea' => 'is-invalid',
-                    'errors' => 'invalid-feedback d-block',
+                    'group_errors' => 'invalid-feedback d-block',
                     'group_help_text' => 'invalid-feedback d-block',
                 ],
             ],


### PR DESCRIPTION
The errors block was being incorrectly hidden due to the invalid classes not matching.
As reported here: https://github.com/glhd/aire/issues/33